### PR TITLE
we now pass selected text as URL 'quote' parameter for Facebook

### DIFF
--- a/dev/shareSelectedText.js
+++ b/dev/shareSelectedText.js
@@ -128,7 +128,7 @@
             twitterUrl += `&via=${parameters.twitterUsername}`;
         }
 
-        let facebookUrl = `https://facebook.com/dialog/share?display=${parameters.facebookDisplayMode}&href=${PAGE_URL}&quote="${text}"`;
+        let facebookUrl = `https://facebook.com/dialog/share?display=${parameters.facebookDisplayMode}&href=${PAGE_URL}&quote=${text}`;
 
         if (document.querySelector('meta[property="fb:app_id"]') &&
             document.querySelector('meta[property="fb:app_id"]').getAttribute('content')) {

--- a/dev/shareSelectedText.js
+++ b/dev/shareSelectedText.js
@@ -128,7 +128,7 @@
             twitterUrl += `&via=${parameters.twitterUsername}`;
         }
 
-        let facebookUrl = `https://facebook.com/dialog/share?display=${parameters.facebookDisplayMode}&href=${PAGE_URL}`;
+        let facebookUrl = `https://facebook.com/dialog/share?display=${parameters.facebookDisplayMode}&href=${PAGE_URL}&quote="${text}"`;
 
         if (document.querySelector('meta[property="fb:app_id"]') &&
             document.querySelector('meta[property="fb:app_id"]').getAttribute('content')) {


### PR DESCRIPTION
This helps to fill in the Facebook share text field by passing it via URL 'quote' parameter